### PR TITLE
Feature/smock/add current based position mode

### DIFF
--- a/config/default_params.yaml
+++ b/config/default_params.yaml
@@ -3,10 +3,11 @@ device_name: /dev/serial/by-id/usb-FTDI_USB__-__Serial_Converter_FT8ISZ8G-if00-p
 kD: 200
 kI: 0
 kP: 600
+percent_current_limit: 100
 pub_current: false
 pub_pos: true
 pub_vel: false
 start_pos_deg: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-joint_feedback_topic: /leap/end_eff/feedback_joint_states
-joint_command_topic: /leap/end_eff/command_joint_states
+joint_feedback_topic: /dom/end_eff/feedback_joint_states
+joint_command_topic: /dom/end_eff/command_joint_states
 dynamixel_type: "XC330-M288"

--- a/config/leap_left_1.yaml
+++ b/config/leap_left_1.yaml
@@ -4,6 +4,7 @@ device_name: /dev/serial/by-id/usb-FTDI_USB__-__Serial_Converter_FT950ZHX-if00-p
 kD: 200
 kI: 0
 kP: 600
+percent_current_limit: 50
 pub_current: false
 pub_pos: true
 pub_vel: false

--- a/config/leap_right_1.yaml
+++ b/config/leap_right_1.yaml
@@ -4,6 +4,7 @@ device_name: /dev/serial/by-id/usb-FTDI_USB__-__Serial_Converter_FT4NQ6SW-if00-p
 kD: 200
 kI: 0
 kP: 600
+percent_current_limit: 50
 pub_current: false
 pub_pos: true
 pub_vel: false

--- a/config/leap_right_2.yaml
+++ b/config/leap_right_2.yaml
@@ -4,6 +4,7 @@ device_name: /dev/serial/by-id/usb-FTDI_USB__-__Serial_Converter_FT8ISZ8G-if00-p
 kD: 200
 kI: 0
 kP: 600
+percent_current_limit: 50
 pub_current: false
 pub_pos: true
 pub_vel: false

--- a/config/leap_right_3.yaml
+++ b/config/leap_right_3.yaml
@@ -4,6 +4,7 @@ device_name: /dev/serial/by-id/usb-FTDI_USB__-__Serial_Converter_FT8ISZ8Z-if00-p
 kD: 200
 kI: 0
 kP: 600
+percent_current_limit: 50
 pub_current: false
 pub_pos: true
 pub_vel: false

--- a/config/test_params.yaml
+++ b/config/test_params.yaml
@@ -3,10 +3,11 @@ device_name: /dev/serial/by-id/usb-FTDI_USB__-__Serial_Converter_FT8ISZ8G-if00-p
 kD: 200
 kI: 0
 kP: 600
+percent_current_limit: 100
 pub_current: false
 pub_pos: true
 pub_vel: false
 start_pos_deg: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-joint_feedback_topic: /leap/end_eff/feedback_joint_states
-joint_command_topic: /leap/end_eff/command_joint_states
+joint_feedback_topic: /dom/end_eff/feedback_joint_states
+joint_command_topic: /dom/end_eff/command_joint_states
 dynamixel_type: "XC330-M288"

--- a/leap_ros2/leap_node.py
+++ b/leap_ros2/leap_node.py
@@ -16,6 +16,7 @@ class LeapHandNode(Node):
         self.declare_parameter("baud_rate", 3000000)
         self.declare_parameter("device_name","")
         self.declare_parameter("dynamixel_type", "")
+        self.declare_parameter("percent_current_limit", 100)
         self.declare_parameter("pub_pos", True)
         self.declare_parameter("pub_vel", False)
         self.declare_parameter("pub_current", False)
@@ -44,7 +45,8 @@ class LeapHandNode(Node):
             raise ValueError(
                 "Please state the dynamixel_type in the configuration file."
             )
-
+        
+        self.percent_current_limit = self.get_parameter("percent_current_limit").get_parameter_value().integer_value
         self.pub_pos = self.get_parameter("pub_pos").get_parameter_value().bool_value
         self.pub_vel = self.get_parameter("pub_vel").get_parameter_value().bool_value
         self.pub_current = self.get_parameter("pub_current").get_parameter_value().bool_value
@@ -81,7 +83,8 @@ class LeapHandNode(Node):
         # Currently operating mode is only set to current based position control!
         self.dynamixel_mgr.set_torque_disable(self.dynamixel_mgr.motor_ids) # Disable torques prior to changing settings
         self.dynamixel_mgr.set_current_based_position_mode(self.dynamixel_mgr.motor_ids)
-        self.dynamixel_mgr.set_current_limit(self.dynamixel_mgr.motor_ids, np.ones(len(motor_ids)) * self.dynamixel_mgr.max_curr_limit)
+        self.dynamixel_mgr.set_current_limit(self.dynamixel_mgr.motor_ids, np.ones(len(motor_ids))
+                                              * self.dynamixel_mgr.max_curr_limit * (self.percent_current_limit/100))
         self.dynamixel_mgr.set_torque_enable(self.dynamixel_mgr.motor_ids)
         self.initialize_gains()
 

--- a/leap_ros2/leap_node.py
+++ b/leap_ros2/leap_node.py
@@ -52,11 +52,12 @@ class LeapHandNode(Node):
         self.kI = self.get_parameter("kI").get_parameter_value().integer_value
         self.kD = self.get_parameter("kD").get_parameter_value().integer_value
         self.start_pos_deg = self.get_parameter("start_pos_deg").get_parameter_value().double_array_value
+        
+        # Current limit that is set based on what type of dynamixel motor
 
         motor_ids = list(range(16))
         if self.dynamixel_type == "XC330-M288":
             self.dynamixel_mgr = XC330M288Manager(motor_ids, self.baud_rate, self.device_name)
-            
             
         elif self.dynamixel_type == "XL330-M288":
             self.dynamixel_mgr = XL330M288Manager(motor_ids, self.baud_rate, self.device_name)
@@ -77,17 +78,18 @@ class LeapHandNode(Node):
         )
 
         # Initialize gains and operating mode
-        # Currently operating mode is only set to position and cannot be changed (TBD!)
+        # Currently operating mode is only set to current based position control!
         self.dynamixel_mgr.set_torque_disable(self.dynamixel_mgr.motor_ids) # Disable torques prior to changing settings
-        self.dynamixel_mgr.set_position_mode(self.dynamixel_mgr.motor_ids)
+        self.dynamixel_mgr.set_current_based_position_mode(self.dynamixel_mgr.motor_ids)
+        self.dynamixel_mgr.set_current_limit(self.dynamixel_mgr.motor_ids, np.ones(len(motor_ids)) * self.dynamixel_mgr.max_curr_limit)
         self.dynamixel_mgr.set_torque_enable(self.dynamixel_mgr.motor_ids)
         self.initialize_gains()
 
         # Set initial position
         self.dynamixel_mgr.set_goal_position_deg(self.dynamixel_mgr.motor_ids, self.start_pos_deg)
 
-        # TODO: This frequency could be an exposed config parameter
-        timer_period = 1.0 / 60.0
+        # TODO: This frequency could be an exposed config parameter - currently goes to 72 hertz which is used for the metaquest for ONR
+        timer_period = 1.0 / 72.0
         self.timer = self.create_timer(timer_period, self.read_and_publish_data)
 
     def initialize_gains(self):


### PR DESCRIPTION
Feature includes the following:

1. Add current based position mode to be the default for the LEAP Hand. This seemed essential since the hand kept on torquing out in position based mode.
2. Add a parameter that dictates the % of maximum current that the LEAP Hand will launch with.
3. Update publishing hz to be 72Hz since thats the frequency of read in by the Meta Quest.
